### PR TITLE
Move RuboCop settings toward compatibility with standardrb

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,11 @@ Layout/MultilineOperationIndentation:
 Layout/SpaceBeforeBlockBraces:
   EnforcedStyleForEmptyBraces: space
 
+# Use standardrb style hash literals
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+  EnforcedStyleForEmptyBraces: no_space
+
 # Assume the programmer knows how bracketed block syntax works
 Lint/AmbiguousBlockAssociation:
   Enabled: false
@@ -52,6 +57,10 @@ Performance/StartWith:
 Style/AndOr:
   EnforcedStyle: conditionals
 
+# Use standardrb style empty methods
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
 # Require at least two dependent lines before suggesting a guard clause
 Style/GuardClause:
   MinBodyLength: 2
@@ -64,18 +73,16 @@ Style/Next:
 Style/NumericPredicate:
   Enabled: false
 
-# Use older RuboCop default
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    '%W': ()
-    '%w': ()
-
 # Allow explicit return with multiple return values
 Style/RedundantReturn:
   AllowMultipleReturnValues: true
 
 # Do not commit to use of interpolation
 Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+# Make quoting outside and inside interpolation consistent
+Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
 # Prefer symbols to look like symbols

--- a/lib/atspi_app_driver.rb
+++ b/lib/atspi_app_driver.rb
@@ -25,7 +25,7 @@ module AtspiAccessiblePatches
   end
 
   def inspect_recursive(level = 0, maxlevel = 5)
-    puts "#{'  ' * level} > name: #{name}; role: #{role}"
+    puts "#{"  " * level} > name: #{name}; role: #{role}"
     each_child do |child|
       child.inspect_recursive(level + 1) unless level >= maxlevel
     end
@@ -66,7 +66,7 @@ class AtspiAppDriver
   end
 
   def spawn_process(arguments)
-    command = "ruby -I#{@lib_dir} #{@app_file} #{arguments.join(' ')}"
+    command = "ruby -I#{@lib_dir} #{@app_file} #{arguments.join(" ")}"
     log "About to spawn: `#{command}`"
     @pid = Process.spawn command
   end


### PR DESCRIPTION
- Update RuboCop configuration
- Autocorrect Style/StringLiteralsInInterpolation offenses
