### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,11 +4,11 @@
 
 name: CI
 
-on:
+"on":
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   schedule:
     - cron: '16 4 12 * *'
 
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7, "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 # Make BeginEndAlignment behavior match EndAlignment
 Layout/BeginEndAlignment:

--- a/atspi_app_driver.gemspec
+++ b/atspi_app_driver.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Test GirFFI-based applications using Atspi"
   spec.homepage = "http://www.github.com/mvz/atspi_app_driver"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/atspi_app_driver"


### PR DESCRIPTION
- Require Ruby 2.7
- Drop testing with Ruby 2.6 from GitHub Actions
- Make RuboCop target Ruby 2.7
