### PR TITLE
Depend on GirFFI-Atspi to provide Atspi bindings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,12 @@ Lint/AmbiguousOperatorPrecedence:
 Lint/AssignmentInCondition:
   AllowSafeAssignment: true
 
+# Test describe blocks and gem specification blocks can be any size
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'
+    - '*.gemspec'
+
 Performance/StartWith:
   AutoCorrect: true
 

--- a/README.md
+++ b/README.md
@@ -11,18 +11,19 @@ code in `lib/`.
 Say, your application is called `foo`. Then, in your tests, do something like this:
 
 ```ruby
-require 'atspi_app_driver'
+require "minitest/autorun"
+require "atspi_app_driver"
 
-describe 'The application' do
+describe "The application" do
   before do
-    @driver = AtspiAppDriver.new('foo')
+    @driver = AtspiAppDriver.new("foo")
 
     # This will boot `ruby -Ilib bin/foo`, wait for its main window to appear,
     # and focus it.
     @driver.boot
   end
 
-  it 'does stuff' do
+  it "does stuff" do
     # Fetch the main window's atspi object
     frame = @driver.frame
 
@@ -31,14 +32,14 @@ describe 'The application' do
     # Select item matching /bar/ from combo box:
     box = frame.find_role :combo_box
     item = box.find_role :menu_item, /bar/
-    box.get_action_name(0).must_equal 'press'
+    _(box.get_action_name(0)).must_equal "press"
     box.do_action 0
-    item.get_action_name(0).must_equal 'click'
+    _(item.get_action_name(0)).must_equal "click"
     item.do_action 0
 
     # Fetch contents of a text box
     textbox = frame.find_role :text
-    textbox.get_text(0, 100).must_equal 'Foo bar baz'
+    _(textbox.get_text(0, 100)).must_equal "Foo bar baz"
 
     # Quit application
     menu_item = frame.find_role :menu_item, /Quit/
@@ -46,7 +47,7 @@ describe 'The application' do
 
     # Check exit status
     status = @driver.cleanup
-    status.exitstatus.must_equal 0
+    _(status.exitstatus).must_equal 0
   end
 
   after do

--- a/atspi_app_driver.gemspec
+++ b/atspi_app_driver.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "gir_ffi-gtk", "~> 0.18.0"
   spec.add_development_dependency "minitest", "~> 5.12"
+  spec.add_development_dependency "minitest-focus", "~> 1.4"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rubocop", "~> 1.51"

--- a/atspi_app_driver.gemspec
+++ b/atspi_app_driver.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.files = File.read("Manifest.txt").split
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "gir_ffi", "~> 0.18.0"
+  spec.add_dependency "gir_ffi-atspi", "~> 0.1.0"
 
   spec.add_development_dependency "gir_ffi-gtk", "~> 0.18.0"
   spec.add_development_dependency "minitest", "~> 5.12"

--- a/lib/atspi_app_driver.rb
+++ b/lib/atspi_app_driver.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "gir_ffi"
-
-GirFFI.setup :Atspi
-Atspi.load_class :Accessible
+require "gir_ffi-atspi"
 
 # Utility monkey-patches for the Atspi::Accessible class
 module AtspiAccessiblePatches

--- a/test/bin/dummy
+++ b/test/bin/dummy
@@ -33,8 +33,11 @@ class Application
 
   def setup_gui
     @win = Gtk::Window.new :toplevel
+    box = Gtk::Box.new :vertical, 0
+    box.add Gtk::Label.new "Hello, World!"
     @button = Gtk::Button.new_with_label "Close"
-    @win.add @button
+    box.add @button
+    @win.add box
   end
 end
 

--- a/test/end_to_end/basic_run_test.rb
+++ b/test/end_to_end/basic_run_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "../test_helper"
-require "atspi_app_driver"
 
 describe "test driving a dummy application" do
   before do
@@ -12,13 +11,14 @@ describe "test driving a dummy application" do
   it "starts and can be quit by activating an action" do
     frame = @driver.frame
     button = frame.find_role :push_button
+    _(button.get_action_name(0)).must_equal "click"
     button.do_action 0
 
     status = @driver.cleanup
     _(status.exitstatus).must_equal 0
   end
 
-  it "provides acces to the main application Atspi object" do
+  it "provides access to the main application Atspi object" do
     app = @driver.application
     _(app.role).must_equal :application
 
@@ -27,6 +27,15 @@ describe "test driving a dummy application" do
 
     status = @driver.cleanup
     _(status.exitstatus).must_equal 0
+  end
+
+  it "provides access to label texts" do
+    frame = @driver.frame
+    label = frame.find_role :label
+    _(label.get_text(0, -1)).must_equal "Hello, World!"
+
+    button = frame.find_role :push_button
+    button.do_action 0
   end
 
   after do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+require "minitest/focus"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,3 +2,4 @@
 
 require "minitest/autorun"
 require "minitest/focus"
+require "atspi_app_driver"


### PR DESCRIPTION
- Modernize minitest example in README
- Add minitest-focus to help in development
- Use `gir_ffi-atspi` to make `Atspi::Accessible#get_text` work again
