### PR TITLE
Update RuboCop setup and fix new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_mode:
   merge:
     - Exclude
 
-require:
+plugins:
   - rubocop-packaging
   - rubocop-performance
   - rubocop-minitest

--- a/atspi_app_driver.gemspec
+++ b/atspi_app_driver.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-focus", "~> 1.4"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.51"
+  spec.add_development_dependency "rubocop", "~> 1.76"
   spec.add_development_dependency "rubocop-minitest", "~> 0.38.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.18"
+  spec.add_development_dependency "rubocop-performance", "~> 1.25"
 end

--- a/test/end_to_end/basic_run_test.rb
+++ b/test/end_to_end/basic_run_test.rb
@@ -11,27 +11,32 @@ describe "test driving a dummy application" do
   it "starts and can be quit by activating an action" do
     frame = @driver.frame
     button = frame.find_role :push_button
+
     _(button.get_action_name(0)).must_equal "click"
     button.do_action 0
 
     status = @driver.cleanup
+
     _(status.exitstatus).must_equal 0
   end
 
   it "provides access to the main application Atspi object" do
     app = @driver.application
+
     _(app.role).must_equal :application
 
     button = app.find_role :push_button
     button.do_action 0
 
     status = @driver.cleanup
+
     _(status.exitstatus).must_equal 0
   end
 
   it "provides access to label texts" do
     frame = @driver.frame
     label = frame.find_role :label
+
     _(label.get_text(0, -1)).must_equal "Hello, World!"
 
     button = frame.find_role :push_button


### PR DESCRIPTION
- Bump versions for RuboCop dependencies
- Use the new rubocop plugins configuration syntax
- Autocorrect Minitest/EmptyLineBeforeAssertionMethods
