### PR TITLE
Fix test for exception with message

### DIFF
--- a/test/end_to_end/basic_run_test.rb
+++ b/test/end_to_end/basic_run_test.rb
@@ -54,7 +54,8 @@ describe "test driving an application without an accessible window" do
   end
 
   it "will fail to boot" do
-    _(proc { @driver.boot }).must_raise RuntimeError, /App not/
+    error = _(proc { @driver.boot }).must_raise RuntimeError
+    _(error.message).must_match(/App not/)
   end
 
   after do


### PR DESCRIPTION
This test used syntax matching how RSpec tests for exceptions with a message. However, this is not how minitest works: Each passed argument is a possible exception to match. With minitest 6.0.5, validation was added that validates this, causing this test to fail.

This change moves the message check to a separate assertion, so now both the class and message are validated.
